### PR TITLE
first pass at adding a github workflow to lock the b4b-dev branhc

### DIFF
--- a/.github/workflows/b4b-dev-auto-lock.yml
+++ b/.github/workflows/b4b-dev-auto-lock.yml
@@ -1,0 +1,47 @@
+name: Lock b4b-dev branch
+
+on:
+  schedule:
+    - cron: '30 23 * * SUN'
+  workflow_dispatch:
+
+jobs:
+  lock-branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Lock b4b-dev branch
+      # curl command and REST data explanation
+      # -L: make curl follow a redirect to the location
+      # -X PUT: send "PUT" request
+      # -H Authorization: pass github "Authorization" header
+      # -H Accept: pass github "Accept" head
+      # -d: data to send
+      # required_status_checks: force branch to be up to date with base before merging
+      # enforce_admins: enforce all configurations given for admins
+      # required_pull_request_reviews: set PR requirements for merging
+      # restrictions: who can push to protected branch (users, teams, apps)
+      # allow_force_pushes
+      # allow_deletions
+      # lock_branch
+      run: |
+        curl -L \
+        -X PUT \
+        -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" \
+        -H "Accept: application/vnd.github+json" \
+        https://api.github.com/repos/${{ github.repository }}/branches/b4b-dev/protection \
+        -d '{
+          "required_status_checks": strict,
+          "enforce_admins": null,
+          "required_pull_request_reviews": {
+            "required_approving_review_count": 1
+            },
+          "restrictions": {
+            "users": ["glemieux"],
+            "teams": []
+          },
+          "allow_force_pushes": false,
+          "allow_deletions": false,
+          "lock_branch": true
+        }'
+    end:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/b4b-dev-auto-lock.yml
+++ b/.github/workflows/b4b-dev-auto-lock.yml
@@ -43,5 +43,5 @@ jobs:
           "allow_deletions": false,
           "lock_branch": true
         }'
-    end:
+    env:
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
This uses REST API calls via curl to set the branch protection

### Description of changes

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
